### PR TITLE
[ADD] 각인 및 트포 지연시간 증가 및 예상 시간 고도화

### DIFF
--- a/src/app/imprinting/functions/search.ts
+++ b/src/app/imprinting/functions/search.ts
@@ -349,7 +349,7 @@ export function getSearchScript(
       }
     }
     
-    const SEARCH_DELAY = 3.2
+    const SEARCH_DELAY = 6.2
     async function getSearchResult(imprints, accTypes, accMap, overlapping, searchGrade) {
       const result = [];
       const total = imprints.length * accTypes.length;

--- a/src/app/tripod/functions/search.ts
+++ b/src/app/tripod/functions/search.ts
@@ -180,7 +180,7 @@ export function getSearchScript(classCode: number, tripods: TripodValue[][]) {
       }
     }
     
-    const SEARCH_DELAY = 3.2
+    const SEARCH_DELAY = 6.2
     async function getSearchResult(classCode, tripods) {
       const result = [];
       const total = tripods.length;

--- a/src/app/tripod/functions/search.ts
+++ b/src/app/tripod/functions/search.ts
@@ -179,17 +179,41 @@ export function getSearchScript(classCode: number, tripods: TripodValue[][]) {
         }
       }
     }
+
+    function getTrimmedAverage(arr) {
+      if (arr.length <= 2) return 700; // default RTT value
+      var max = arr[0];
+      var min = arr[0];
+      var sum = 0;
+      arr.forEach(function (value) {
+        if (value > max) max = value;
+        if (value < min) min = value;
+        sum += value;
+      });
+      return (sum - max - min) / (arr.length - 2);    
+    }
     
-    const SEARCH_DELAY = 6.2
+    const SEARCH_DELAY = 6.2;
     async function getSearchResult(classCode, tripods) {
       const result = [];
+      const prevRTTMs = [];
+      let prevStartedTimeMs = -1;
       const total = tripods.length;
       let count = 0;
       for (const tripod of tripods) {
-          count += 1;
-          const estimated = new Date();
-          estimated.setSeconds(estimated.getSeconds() + (total - count) * SEARCH_DELAY);
-          console.log(\`검색 진행중 - \${count} / \${total}\n예상 완료 시각: \${estimated.toLocaleTimeString()}\`)
+        count += 1;
+        if(prevStartedTimeMs > 0) {
+          if(prevRTTMs.length >= 10) prevRTTMs.shift();
+          prevRTTMs.push(Date.now() - prevStartedTimeMs - SEARCH_DELAY * 1000);
+        }
+        prevStartedTimeMs = Date.now();
+        const estimatedFinishTime = new Date();
+        const estimatedDuration = (total - count + 1) * (SEARCH_DELAY + getTrimmedAverage(prevRTTMs) / 1000);
+        estimatedFinishTime.setSeconds(estimatedFinishTime.getSeconds() + estimatedDuration);
+        const estimatedDurationDate = new Date(0);
+        estimatedDurationDate.setSeconds(estimatedDuration);
+        const estimatedDurationString = \`\${estimatedDurationDate.getMinutes()}분 \${estimatedDurationDate.getSeconds()}초\`;
+        console.log(\`검색 진행중 - \${count} / \${total}\n예상 완료 시각: \${estimatedFinishTime.toLocaleTimeString()}, 예상 남은 시간: \${estimatedDurationString}\`);
           
           const { products, totalPages } = await trySearch({
             classNo: classCode,


### PR DESCRIPTION
- 지연 시간 2배 가량 증가
- 예상 완료 시각에서 마지막 검색을 고려하지 않던 내용 수정
- 예상 완료 시각 계산 시 서버 단의 딜레이를 고려하는 기능 추가 (최근 10개에서 최대/최솟값 제외 평균)
- 예상 남은 시간 표시 추가
![예상 남은 시간 표시](https://user-images.githubusercontent.com/23402478/177694799-aa851d10-cd1f-450f-9bd4-8aeeda9f0742.png)

