### PR TITLE
재련 2023 겨울 슈모익 적용

### DIFF
--- a/src/app/refining/containers/refining-item.component.html
+++ b/src/app/refining/containers/refining-item.component.html
@@ -68,12 +68,12 @@
   </div>
   <div>
     <mat-checkbox formControlName="applyHyperExpress"
-      >하익 성장지원 적용</mat-checkbox
+      >슈모익 성장지원 적용</mat-checkbox
     >
   </div>
-  <div>
+  <!-- <div>
     <mat-checkbox formControlName="applyKamenRoad"
       >카멘로드 성장지원 적용</mat-checkbox
     >
-  </div>
+  </div> -->
 </form>

--- a/src/app/refining/data.ts
+++ b/src/app/refining/data.ts
@@ -1309,6 +1309,7 @@ export function getRefineTable(
   let additionalProb = 0;
   let costReduction = 0;
   let goldReduction = 0;
+  let goldCeilUnit = 1;
   let janginMultiplier = 1;
   if (itemGrade === 't3_1250' && refineTarget <= 12) {
     additionalProb = 0.1;
@@ -1327,6 +1328,7 @@ export function getRefineTable(
   }
   if (itemGrade === 't3_1390' && refineTarget >= 1 && refineTarget <= 20) {
     goldReduction = 0.4;
+    goldCeilUnit = 1;
   }
 
   if (applyResearch) {
@@ -1341,19 +1343,27 @@ export function getRefineTable(
     }
   }
 
-  if (applyHyperExpress) {
+  if (applyHyperExpress) { // 2023 Winter, Super Mococo Express
     if (itemGrade === 't3_1390' && refineTarget === 13) {
       additionalProb += 0.1;
     }
     if (itemGrade === 't3_1390' && refineTarget >= 14 && refineTarget <= 15) {
       additionalProb += 0.05;
     }
-    if (itemGrade === 't3_1390' && refineTarget >= 13 && refineTarget <= 15) {
-      costReduction += 0.2;
-      goldReduction += 0.2;
+    if (itemGrade === 't3_1390' && refineTarget >= 16 && refineTarget <= 17) {
+      additionalProb += 0.04;
+    }
+    if (itemGrade === 't3_1390' && refineTarget >= 18 && refineTarget <= 19) {
+      additionalProb += 0.03;
+    }
+
+    if (itemGrade === 't3_1390' && refineTarget >= 13 && refineTarget <= 19) {
+      goldReduction += 0.25;
+      costReduction += 0.6;
+      goldCeilUnit = 1;
     }
   }
-
+/*
   if (applyKamenRoad) {
     if (itemGrade === 't3_1390' && refineTarget >= 16 && refineTarget <= 17) {
       additionalProb += 0.02;
@@ -1366,7 +1376,7 @@ export function getRefineTable(
       janginMultiplier = 2;
     }
   }
-
+*/
   additionalProb = Math.round(additionalProb * 1000) / 1000;
 
   return {
@@ -1376,7 +1386,7 @@ export function getRefineTable(
       Object.entries(data.amount).map(([name, value]) => [
         name,
         name === '골드'
-          ? Math.ceil(value * (1 - goldReduction))
+          ? Math.ceil(value * (1 - goldReduction) / goldCeilUnit) * goldCeilUnit
           : Math.round(value * (1 - costReduction)),
       ])
     ),

--- a/src/app/refining/data.ts
+++ b/src/app/refining/data.ts
@@ -1328,7 +1328,7 @@ export function getRefineTable(
   }
   if (itemGrade === 't3_1390' && refineTarget >= 1 && refineTarget <= 20) {
     goldReduction = 0.4;
-    goldCeilUnit = 1;
+    goldCeilUnit = 10;
   }
 
   if (applyResearch) {


### PR DESCRIPTION
확인된 슈모익 할인율
- 1390 장비 13단계 확률 +10%p
- 1390 장비 14~15단계 확률 +5%p
- 1390 장비 16~17단계 확률 +4%p
- 1390 장비 18~19단계 확률 +3%p
- 1390 장비 13~19단계 골드 감소 65%
- 1390 장비 13~19단계 비용 감소 60% 
(못 찾은 것인지 인게임이나 이벤트 페이지에서 수치를 확인할 수는 없었고, 재료 대비 역산한 수치입니다. 방어구 기준 전 구간 수호석 결정 개수 확인했습니다.)

확인된 비-슈모익 할인율
- 1390 장비 13~19단계 골드 감소 40%

특이사항
- 슈모익 적용이 없는 기준으로, 해당 구간은 골드를 10의 단위로 올림하는 것으로 확인되어 해당 로직 추가
  - 슈모익 미적용, 방어구 14강 ~~312~~ 320G / 15강 ~~336~~ 340G / 16강 ~~402~~ 410G / 무기 16강 ~~672~~ 680G 으로 확인
  - 슈모익 적용, 방어구 14~19강 구간 1의 단위 올림 확인 완료(19강 301G)